### PR TITLE
chore: refactor code to initialize variables

### DIFF
--- a/TestProjectForHolyWater/Assets/LoadSystem/Scripts/JsonCheckOperation.cs
+++ b/TestProjectForHolyWater/Assets/LoadSystem/Scripts/JsonCheckOperation.cs
@@ -15,11 +15,11 @@ public class JsonCheckOperation
         try
         {
             jsonPack = JsonUtility.FromJson<JsonPack>(File.ReadAllText(jsonPath));
-            Debug.Log("Json файл найден!");
+            Debug.Log("Json пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ!");
         }
         catch
         {
-            Debug.Log("Json файл не найден!");
+            Debug.Log("Json пїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ!");
             jsonPack = null;
         }
         return jsonPack;
@@ -27,7 +27,7 @@ public class JsonCheckOperation
 
     public async Task<JsonPack> DonwloadNewJson()
     {
-        JsonPack jsonPack;
+        JsonPack jsonPack = null;
         string jsonPath = Application.persistentDataPath + "/" + "Temp" + JsonManager.JSON_FILE_NAME;
 
         Task<bool> downloadTask = DownloadOperaion.Download(JSON_FILE_URL, jsonPath);
@@ -37,7 +37,6 @@ public class JsonCheckOperation
         {
             jsonPack = JsonUtility.FromJson<JsonPack>(File.ReadAllText(jsonPath));
         }
-        else jsonPack = null;
 
         return jsonPack;
     }


### PR DESCRIPTION
# WHAT

Instead of not initializing the variable, and then assigning a value when the `if` is not executed (you could do the same in the previous `try/catch`), you can set a default value in the variable that will be overwritten if the condition is met (less code and you don't need to think about the `else` or `catch`, as the default value is enough)

*This is a styling thing, both ways are correct, but I tend to do it this way*. When the `if/else` conditions are simple, you can always use the [ternary operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/conditional-operator) but I'm not a big fan as sometimes devs overcomplicate it with ternary conditions under ternary conditions (machines will always understand your code, eve if it's "smart", but other developers reading your code may not)
